### PR TITLE
Fix installation

### DIFF
--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -55,7 +55,9 @@ export default class Install extends Command {
   private oldDeps = [
     '@headlessui/vue',
     '@heroicons/vue',
+    '@inertiajs/inertia',
     '@inertiajs/inertia-vue3',
+    '@inertiajs/progress',
     '@vue/compiler-sfc',
     'vue',
     'vue-loader',
@@ -136,6 +138,8 @@ export default class Install extends Command {
     if (!flags.teams) {
       this.removeTeams();
     }
+
+    this.log('Installation complete. Enjoy :)');
   }
 
   private moveStub(stubPath: string, localPath: string) {


### PR DESCRIPTION
When running `npx laravel-jetstream-react install` on a new installation, this would fail because the initial jetstream `package.json` has inertia hardcoded at a specific version and once that gets out of date, trying to install the react adapter is no longer compatible. 

This pr removes the old version of `@inertiajs/inertia` and then installs it again with the normal dependencies